### PR TITLE
[#163606665] renaming errand

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -143,7 +143,7 @@ do the following:
 
     ![Errands page](errands.png)
 
-1. Confirm that **Run config scans on PAS** is set to **Default (Off)**.
+1. Confirm that **Run configured scans** is set to **Default (Off)**.
 
 1. Click **Save**.
 

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -50,7 +50,7 @@ To begin scanning, do the following:
 
 1. Click **REVIEW PENDING CHANGES**.
 
-1. Enable the checkboxes for the <%= vars.product_short %> tile and the **Run config scans on PAS** errand.
+1. Enable the checkboxes for the <%= vars.product_short %> tile and the **Run configured scans** errand.
 
     ![Review pending changes page with Compliance Scanner for PCF selected and Run config scans on P
     AS errand selected](review-pending-changes.png)


### PR DESCRIPTION
renaming errand Run config scans on PAS->Run configured scans

Errand will be renamed as of the next release onward, so no need to cherry pick.