### PR TITLE
Remove open file limit configuration

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -118,15 +118,12 @@ This section is where you configure expected values for tests and select which s
     </table>
     <br><br>
     A scan report is generated for each format and benchmark on each Linux VM running on Xenial stemcells.
-    For example, if you select **.xml** and **.log** formats,
-    and **Base Xenial** and **STIG** benchmarks, four log files are created for each VM tested.
+    For example, if you select **.xml** and **.csv** formats,
+    and **Base Xenial** and **STIG** benchmarks, four csv files are created for each VM tested.
     <br><br>
     For more information about <%= vars.product_short %> benchmarks, see [Benchmarks](./benchmarks.html).
 
 1. For **Scanner Timeout**, configure the maximum time in seconds permitted for a scan. The default value is `600`.
-
-1. For **Open File Limit**, configure the maximum number of files that the scanner is permitted to open.
-If the scanner goes over this limit, the scan fails. The recommended value is at least 1024 plus twice the number of VMs.
 
 1. Click **Save**.
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -16,7 +16,6 @@ New features and changes in this release:
 * Adds ability to cancel running scans.
 * Adds ability to store scan results in Amazon S3 Buckets and MinIO Object Storage.
 * Adds compatibility with STIG viewer.
-* Adds ability to configure **Open File Limit** in the tile.
 * Adds additional logging for test duration and timestamps.
 * Replace log formatted output with the csv format.
 * Updates packaged benchmarks.


### PR DESCRIPTION
We are removing the ability to configure the open file limit, as operators shouldn't need to concern themselves with this.

Also, replace the .log format with .csv (as this also changed in the release)

Signed-off-by: Dimitry Besson <dimitrybesson@pivotal.io>